### PR TITLE
Added OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- kostasakrivos
+- Petlyuk-Vladimir
+reviewers:
+- kostasakrivos
+- Petlyuk-Vladimir


### PR DESCRIPTION
This file is required from jenkins-x to verify that a PR has been approved by its relevant owners, and thus recording that the PR has not been manually approved by just adding the 'approved' label.